### PR TITLE
Update OutOfOfficeSieveServer.js

### DIFF
--- a/chrome/content/editor/OutOfOfficeSieveServer.js
+++ b/chrome/content/editor/OutOfOfficeSieveServer.js
@@ -403,6 +403,7 @@ var gEventConnection =
         }
 */        if(gTryToCreate == true /*&& response.getMessage()*/ ){
             gOutOfOfficeSieveServer.createScript();
+            gOutOfOfficeSieveServer.activateScript();
             gTryToCreate = false;
             return;
         }


### PR DESCRIPTION
If the file "OutOfOfficeScriptFile.sieve" does not exist on the Sieve server and you click on the "Enable"-button in the "Out of Office Account List", the file "OutOfOfficeScriptFile.sieve" becomes created on the server but not activated.
The Problem is, in the account list the account is marked as activated (but on the server it's not).
This line fixes this.
